### PR TITLE
STAT-878 remove assets from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,5 @@ public/
 bower_components/
 
 # Assets folder from the scraper
-assets/
+app/assets/index.html
+app/assets/vendor/

--- a/orig.gitignore
+++ b/orig.gitignore
@@ -1,0 +1,36 @@
+# Numerous always-ignore extensions
+*.diff
+*.err
+*.orig
+*.log
+*.rej
+*.swo
+*.swp
+*.vi
+*~
+*.sass-cache
+
+# OS or Editor folders
+.DS_Store
+.cache
+.project
+.settings
+.tmproj
+nbproject
+Thumbs.db
+
+# NPM packages folder.
+node_modules/
+
+# Brunch folder for temporary files.
+tmp/
+
+# Brunch output folder.
+public/
+
+# Bower stuff.
+bower_components/
+
+# Assets folder from the scraper
+app/assets/index.html
+app/assets/vendor/

--- a/skeleton.js
+++ b/skeleton.js
@@ -61,6 +61,7 @@ scraper.scrape( {
 	if ( results ) {
 		file = this.options.directory + '/' + results[0].filename;
 		loadSkeleton( processSkeleton );
+		loadIgnore( processIgnore );
 	}
 } ).catch( function( err ) {
 	console.log( err.message );
@@ -132,4 +133,25 @@ function adPlaceholders( data ) {
 
 function getPlaceholder( width, height ) {
 	return  '<div style="box-sizing: border-box; width: ' + width + 'px; height: ' + height + 'px; background-color: #CCCCCC; text-align: center; margin: 0 auto; padding-top: 1em; font-weight: bold;"><p style="color: #969696;">' + width + 'x' + height + '</p></div>';
+}
+
+
+/**
+ * Remove the followingn from .gitignore:
+ * app/assets/index.html
+ * app/assets/vendor/
+ */
+function loadIgnore( callback ) {
+	fs.readFile( '.gitignore', 'utf8', callback );
+}
+
+function processIgnore(er, data ) {
+	data.replace( 'app/assets/index.html', '' );
+	data.replace( 'app/assets/vendor/', '' );
+
+	writeIgnore( data );
+}
+
+function writeIgnore( data ) {
+	fs.writeFile( '.gitignore', data );
 }

--- a/skeleton.js
+++ b/skeleton.js
@@ -1,7 +1,7 @@
 var scraper = require( 'website-scraper' );
 var fs = require( 'fs' );
 var cheerio = require( 'cheerio' );
-var file;
+var file, ign;
 
 scraper.scrape( {
 	urls: [ 'https://stat.qa.wordpress.boston.com/2016/04/04/stat-dataviz-skeleton-post/' ],
@@ -136,16 +136,26 @@ function getPlaceholder( width, height ) {
 }
 
 
-/**
- * Remove the followingn from .gitignore:
- * app/assets/index.html
- * app/assets/vendor/
- */
+// Remove app/assets/index.html & app/assets/vendor/ from .gitignore
 function loadIgnore( callback ) {
-	fs.readFile( '.gitignore', 'utf8', callback );
+
+	fs.readdir( process.cwd(), function( err, files ) {
+		if (err){
+			throw err;
+		} else {
+			ign = files.indexOf( '.gitignore' ) ? './.gitignore' : '';
+		}
+	});
+	if ( ign ) {
+		fs.readFile( ign, 'utf8', callback );
+	}
 }
 
-function processIgnore(er, data ) {
+function processIgnore(err, data ) {
+	if ( err ) {
+		throw err;
+	}
+
 	data.replace( 'app/assets/index.html', '' );
 	data.replace( 'app/assets/vendor/', '' );
 
@@ -153,5 +163,5 @@ function processIgnore(er, data ) {
 }
 
 function writeIgnore( data ) {
-	fs.writeFile( '.gitignore', data );
+	fs.writeFile( ign, data );
 }

--- a/skeleton.js
+++ b/skeleton.js
@@ -1,7 +1,7 @@
 var scraper = require( 'website-scraper' );
 var fs = require( 'fs' );
 var cheerio = require( 'cheerio' );
-var file, ign;
+var file;
 
 scraper.scrape( {
 	urls: [ 'https://stat.qa.wordpress.boston.com/2016/04/04/stat-dataviz-skeleton-post/' ],
@@ -138,17 +138,7 @@ function getPlaceholder( width, height ) {
 
 // Remove app/assets/index.html & app/assets/vendor/ from .gitignore
 function loadIgnore( callback ) {
-
-	fs.readdir( process.cwd(), function( err, files ) {
-		if (err){
-			throw err;
-		} else {
-			ign = files.indexOf( '.gitignore' ) ? './.gitignore' : '';
-		}
-	});
-	if ( ign ) {
-		fs.readFile( ign, 'utf8', callback );
-	}
+	fs.readFile( '.gitignore', 'utf8', callback );
 }
 
 function processIgnore(err, data ) {
@@ -156,12 +146,12 @@ function processIgnore(err, data ) {
 		throw err;
 	}
 
-	data.replace( 'app/assets/index.html', '' );
-	data.replace( 'app/assets/vendor/', '' );
+	data = data.replace( 'app/assets/index.html', '' );
+	data = data.replace( 'app/assets/vendor/', '' );
 
 	writeIgnore( data );
 }
 
 function writeIgnore( data ) {
-	fs.writeFile( ign, data );
+	fs.writeFile( '.gitignore', data );
 }


### PR DESCRIPTION
- copied the original gitignore to preserve the required list
  - When making updates to the gitignore file, make sure that the orig. version is updated as well.
  - Confirm _before_ committing code changes that the two files match
- Updated skeleton to remove the assets dirs from the gitignore
  - This will allow those dirs to be included when using brunch to add the skeleton to the dataviz repo
