### PR TITLE
Brunch dataviz skeleton loading tweaks for STAT Plus compatiblity

### DIFF
--- a/app/initialize.js
+++ b/app/initialize.js
@@ -1,6 +1,8 @@
 // Note: there's no longer any need to wait for DOMContentReady here as we
-// not use jQuery.ready() in order to handle this logic directly in index.html
-// prior to attempting to load this 'initialize' CommonJS module.
+// now use jQuery.ready() in order to handle the DOM ready logic directly within
+// index.html prior to attempting to load this 'initialize' CommonJS module.
+// This means that you can count on the document being fully ready by the
+// time this file (and all its dependencies) get loaded.
 
-// Initialize your main JS module here. For example:
+// Initialize/require your main JS module(s) here. For example:
 // var concussion = require('js/concussions');

--- a/app/initialize.js
+++ b/app/initialize.js
@@ -1,4 +1,6 @@
-document.addEventListener('DOMContentLoaded', function() {
-  // Initialize your main JS module here. For example:
-  // var concussion = require('js/concussions');
-});
+// Note: there's no longer any need to wait for DOMContentReady here as we
+// not use jQuery.ready() in order to handle this logic directly in index.html
+// prior to attempting to load this 'initialize' CommonJS module.
+
+// Initialize your main JS module here. For example:
+// var concussion = require('js/concussions');

--- a/app/initialize.js
+++ b/app/initialize.js
@@ -4,5 +4,5 @@
 // This means that you can count on the document being fully ready by the
 // time this file (and all its dependencies) get loaded.
 
-// Initialize/require your main JS module(s) here. For example:
+// Initialize/require your main JS module here. For example:
 // var concussion = require('js/concussions');

--- a/stat-skeleton.js
+++ b/stat-skeleton.js
@@ -317,22 +317,21 @@ function replaceContent( data ) {
 	$( '.post-widgets' ).html( '' );
 	$( 'article.content-article' ).html( `
 		<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
-		<!-- Dataviz container start -->
 		<figure class="stat-dataviz media media-break">
 			<div class="media-content">
+				<!-- Dataviz container start -->
 				<div class="dataviz-${vizNum}">
 					<p><strong>Visualization code goes here.</strong> Please target JS and CSS to the <code>.dataviz-${vizNum}</code> class.</p>
 					<p>Each data visualization gets a unique CSS class so that multiple visualizations can appear on the same page.</p>
 				</div>
+				<!-- Dataviz container end -->
 			</div>
 			<figcaption class="media-label">
 				<cite class="media-credit">Test Author/STAT</cite>
 				<span class="media-source">Source: <a href="#">Test Source</a></span>
 			</figcaption>
 		</figure>
-		<!-- Dataviz container end -->
-
+		<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
 	` );
 
 	return $.html();

--- a/stat-skeleton.js
+++ b/stat-skeleton.js
@@ -8,119 +8,119 @@ var args = process.argv.slice( 2 );
 var defaultUrl = 'https://www.statnews.com/2016/03/25/zika-globe-interactive/';
 
 var promptUrlSchema = {
-  properties: {
-    url: {
-      required: false,
-      type: 'string',
-      default: defaultUrl
-    }
-  }
+	properties: {
+		url: {
+			required: false,
+			type: 'string',
+			default: defaultUrl
+		}
+	}
 };
 
 if ( args.includes( '--silent' ) ) {
-  beginScraping( defaultUrl );
+	beginScraping( defaultUrl );
 } else {
-  let dirExists = fs.existsSync( 'app/assets' );
-  if ( dirExists ) {
-    // console.log( 'Warning: the app/assets directory exists. Overwrite?' );
-    promptUrlSchema.properties.overwrite = {
-      required: true,
-      type: 'string',
-      validator: /[YNyn]/,
-      warning: 'Please enter Y or N.',
-      message: 'Overwrite app/assets directory? (Y/N)'
-    }
-  }
-  prompt.start();
-  prompt.get( promptUrlSchema, function( err, result ) {
-    if ( dirExists && result.overwrite.toLowerCase() !== 'y' ) {
-      process.exit();
-    }
-    if ( dirExists ) {
-      rimraf( 'app/assets', function( err ) {
-        if ( err ) {
-      		throw err;
-      	}
-        beginScraping( result.url );
-      } );
-    } else {
-      beginScraping( result.url );
-    }
-  } );
+	let dirExists = fs.existsSync( 'app/assets' );
+	if ( dirExists ) {
+		// console.log( 'Warning: the app/assets directory exists. Overwrite?' );
+		promptUrlSchema.properties.overwrite = {
+			required: true,
+			type: 'string',
+			validator: /[YNyn]/,
+			warning: 'Please enter Y or N.',
+			message: 'Overwrite app/assets directory? (Y/N)'
+		}
+	}
+	prompt.start();
+	prompt.get( promptUrlSchema, function( err, result ) {
+		if ( dirExists && result.overwrite.toLowerCase() !== 'y' ) {
+			process.exit();
+		}
+		if ( dirExists ) {
+			rimraf( 'app/assets', function( err ) {
+				if ( err ) {
+					throw err;
+				}
+				beginScraping( result.url );
+			} );
+		} else {
+			beginScraping( result.url );
+		}
+	} );
 }
 
 function beginScraping( url ) {
-  if ( ! args.includes( '--silent' ) ) {
-    console.log( 'Creating dataviz skeleton...' );
-  }
+	if ( !args.includes( '--silent' ) ) {
+		console.log( 'Creating dataviz skeleton...' );
+	}
 
-  scraper.scrape( {
-  	urls: [ url ],
-  	directory: 'app/assets/',
-  	subdirectories: [
-  		{
-  			directory: 'vendor/stat/img',
-  			extensions: [ '.png', '.jpg', '.jpeg', '.gif', '.svg' ]
-  		},
-  		{
-  			directory: 'vendor/stat/js',
-  			extensions: [ '.js' ]
-  		},
-  		{
-  			directory: 'vendor/stat/css',
-  			extensions: [ '.css' ]
-  		},
-  		{
-  			directory: 'vendor/stat/fonts',
-  			extensions: [ '.ttf', '.woff', '.woff2', '.eot' ]
-  		}
-  	],
-  	sources: [
-  		{ selector: 'img',
-  			attr: 'src'
-  		},
-  		{
-  			selector: 'input',
-  			attr: 'src'
-  		},
-  		{
-  			selector: 'object',
-  			attr: 'data'
-  		},
-  		{
-  			selector: 'embed',
-  			attr: 'src'
-  		},
-  		{
-  			selector: 'param[name="movie"]',
-  			attr: 'value'
-  		},
-  		{
-  			selector: 'script',
-  			attr: 'src'
-  		},
-  		{
-  			selector: 'link[rel="stylesheet"]',
-  			attr: 'href'
-  		},
-  		{
-  			selector: 'link[rel*="icon"]',
-  			attr: 'href'
-  		}
-  	],
-  	urlFilter: function( url ) {
-  		// Don't save the ComScore tracking pixel.
-  		// This would otherwise be saved to app/assets/p2.
-  		return ( url.indexOf( 'scorecardresearch.com' ) === -1 );
-  	}
-  } ).then( function( results ) {
-  	if ( results ) {
-  		file = this.options.directory + '/' + results[0].filename;
-  		fs.readFile( file, 'utf8', processSkeleton );
-  	}
-  } ).catch( function( err ) {
-  	console.log( err.message );
-  } );
+	scraper.scrape( {
+		urls: [url],
+		directory: 'app/assets/',
+		subdirectories: [
+			{
+				directory: 'vendor/stat/img',
+				extensions: ['.png', '.jpg', '.jpeg', '.gif', '.svg']
+			},
+			{
+				directory: 'vendor/stat/js',
+				extensions: ['.js']
+			},
+			{
+				directory: 'vendor/stat/css',
+				extensions: ['.css']
+			},
+			{
+				directory: 'vendor/stat/fonts',
+				extensions: ['.ttf', '.woff', '.woff2', '.eot']
+			}
+		],
+		sources: [
+			{ selector: 'img',
+				attr: 'src'
+			},
+			{
+				selector: 'input',
+				attr: 'src'
+			},
+			{
+				selector: 'object',
+				attr: 'data'
+			},
+			{
+				selector: 'embed',
+				attr: 'src'
+			},
+			{
+				selector: 'param[name="movie"]',
+				attr: 'value'
+			},
+			{
+				selector: 'script',
+				attr: 'src'
+			},
+			{
+				selector: 'link[rel="stylesheet"]',
+				attr: 'href'
+			},
+			{
+				selector: 'link[rel*="icon"]',
+				attr: 'href'
+			}
+		],
+		urlFilter: function( url ) {
+			// Don't save the ComScore tracking pixel.
+			// This would otherwise be saved to app/assets/p2.
+			return ( url.indexOf( 'scorecardresearch.com' ) === -1 );
+		}
+	} ).then( function( results ) {
+		if ( results ) {
+			file = this.options.directory + '/' + results[0].filename;
+			fs.readFile( file, 'utf8', processSkeleton );
+		}
+	} ).catch( function( err ) {
+		console.log( err.message );
+	} );
 }
 
 function processSkeleton( err, data ) {
@@ -129,6 +129,7 @@ function processSkeleton( err, data ) {
 	}
 
 	data = removeScripts( data );
+	data = removeNoScripts( data );
 	data = removeStyles( data );
 	data = removeMeta( data );
 	data = removeLinkRels( data );
@@ -151,28 +152,39 @@ function removeScripts( data ) {
 			'vendor/stat/js/AppMeasurement.js',
 			'vendor/stat/js/stat-adobe-analytics.js',
 			'vendor/stat/js/zikaglobe.min.js',
-			'vendor/stat/js/trendmd.min.js'
+			'vendor/stat/js/trendmd.min.js',
+			'vendor/stat/js/statnews-rc.js'
 		],
 		scriptContains = [
 			'gpt.js',
 			'dfpBreakpoints',
-      'statGlobal.dfp',
+			'statGlobal.dfp',
 			'dfpBuiltMappings',
 			'wp-emoji-release.min.js',
 			'TrendMD.register', // TrendMD
 			'_sf_startpt', // Chartbeat
 			'loadChartbeat', // Chartbeat
 			'ml314.com', // Bombora
-			's_code' // Omniture
+			's_code', // Omniture
+			'_comscore', // comScore
+			'fbevents.js' // Facebook Pixel
 		];
 
-	for ( i = 0; i < scriptSrcs.length; i ++ ) {
+	for ( i = 0; i < scriptSrcs.length; i++ ) {
 		$( 'script[src="' + scriptSrcs[i] + '"]' ).remove();
 	}
 
-	for ( i = 0; i < scriptContains.length; i ++ ) {
+	for ( i = 0; i < scriptContains.length; i++ ) {
 		$( 'script:contains("' + scriptContains[i] + '")' ).remove();
 	}
+
+	return $.html();
+}
+
+function removeNoScripts( data ) {
+	var $ = cheerio.load( data );
+
+	$( 'noscript' ).remove();
 
 	return $.html();
 }
@@ -184,7 +196,7 @@ function removeStyles( data ) {
 			'vendor/stat/css/zikaglobe.css'
 		];
 
-	for ( i = 0; i < linkHrefs.length; i ++ ) {
+	for ( i = 0; i < linkHrefs.length; i++ ) {
 		$( 'link[href="' + linkHrefs[i] + '"]' ).remove();
 	}
 
@@ -221,7 +233,7 @@ function removeMeta( data ) {
 			'article:tag'
 		];
 
-	for ( var i = 0; i < meta.length; i ++ ) {
+	for ( var i = 0; i < meta.length; i++ ) {
 		$( 'meta[property="' + meta[i] + '"]' ).remove();
 		$( 'meta[name="' + meta[i] + '"]' ).remove();
 	}
@@ -245,7 +257,7 @@ function removeLinkRels( data ) {
 			'shortlink'
 		];
 
-	for ( var i = 0; i < rels.length; i ++ ) {
+	for ( var i = 0; i < rels.length; i++ ) {
 		$( 'link[rel="' + rels[i] + '"]' ).remove();
 	}
 
@@ -256,7 +268,7 @@ function addAppScripts( data ) {
 	var $ = cheerio.load( data );
 
 	$( 'head' ).append( '<link rel="stylesheet" href="app.css" type="text/css" media="screen">' + "\n" );
-	$( 'body' ).append( '<script src="app.js"></script><script>require(\'initialize\');</script>' + "\n" );
+	$( 'body' ).append( '<script src="app.js"></script><script>jQuery( function( $ ) { if ( $( \'.stat-dataviz\' ).length ) { require( \'initialize\' ); } } );</script>' + "\n" );
 
 	return $.html();
 }
@@ -286,17 +298,17 @@ function getPlaceholder( width, height ) {
 		`;
 }
 
-function getRandomInt(min, max) {
+function getRandomInt( min, max ) {
 	// From https://mdn.io/math-random
-  min = Math.ceil(min);
-  max = Math.floor(max);
-  return Math.floor(Math.random() * (max - min)) + min;
+	min = Math.ceil( min );
+	max = Math.floor( max );
+	return Math.floor( Math.random() * ( max - min ) ) + min;
 }
 
 function replaceContent( data ) {
 	var $ = cheerio.load( data ),
 		title = 'STAT Dataviz Skeleton',
-		vizNum = getRandomInt(0, 9999999);
+		vizNum = getRandomInt( 0, 9999999 );
 
 	$( 'title' ).text( title );
 	$( '.header-inner .article-title' ).text( title );

--- a/stat-skeleton.js
+++ b/stat-skeleton.js
@@ -268,7 +268,7 @@ function addAppScripts( data ) {
 	var $ = cheerio.load( data );
 
 	$( 'head' ).append( '<link rel="stylesheet" href="app.css" type="text/css" media="screen">' + "\n" );
-	$( 'body' ).append( '<script src="app.js"></script><script>jQuery( function( $ ) { if ( $( \'.stat-dataviz\' ).length ) { require( \'initialize\' ); } } );</script>' + "\n" );
+	$( 'body' ).append( '<script src="app.js"></script><script>jQuery( function( $ ) { require( \'initialize\' ); } );</script>' + "\n" );
 
 	return $.html();
 }


### PR DESCRIPTION
This mainly implements some Brunch dataviz skeleton changes to make the loading strategy compatible with what I implemented in https://github.com/statnews/wordpress/pull/429 to fix STAT-1808.

I also synced up this dataviz with this most recent skeleton logic so that  you can use it as a test on your local to vet that this works properly: http://apps.statnews.com/illicitdrugs-brunch/public/

See also the changelog for a few other tweaks I made. Let me know if you want me to make any tweaks to this before we merge. Thanks!